### PR TITLE
Nil struct init

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+# OS specific files
+.DS_Store
+.Trash-*
+Thumbs.db
+
 # Compiled Object files, Static and Dynamic libs (Shared Objects)
 *.o
 *.a

--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ test:
         params: 
             p1: mega
             flag: true
+		items:
+			- field_one: value
+			  field_two: value
+		options:
+			username: john_connor
+			password: qwerty
 ```
 
 Sample executable:
@@ -29,6 +35,11 @@ import (
 	"github.com/enuan/gonfoo"
 )
 
+type Options struct {
+	Username string
+	Password string
+}
+
 var config struct {
 	Host   string
 	Port   int
@@ -37,6 +48,13 @@ var config struct {
 		P2   string
 		Flag bool
 	}
+	// slices of any structs
+	Items []struct {
+		FieldOne string
+		FieldTwo string
+	}
+	// Options pointer fields
+	Options *Options
 }
 
 func init() {

--- a/confoo.go
+++ b/confoo.go
@@ -139,6 +139,9 @@ func configPath(path string, dest reflect.Value, conf interface{}) {
 	destKind := dest.Kind()
 	switch destKind {
 	case reflect.Ptr:
+		if dest.Type().Elem().Kind() == reflect.Struct && dest.IsNil() {
+			dest.Set(reflect.New(dest.Type().Elem()))
+		}
 		configPath(path, dest.Elem(), conf)
 	case reflect.Interface:
 		dest.Set(reflect.ValueOf(conf))


### PR DESCRIPTION
The patch allows define complex struct fields as pointers, i.e. optional sub-sections of the config.
Example in the updated README.md 